### PR TITLE
Change FM7 buffer size

### DIFF
--- a/src/games/fm7.c
+++ b/src/games/fm7.c
@@ -11,7 +11,7 @@
 #include "../ForzaTelemetry.h"
 
 #define FM7_PORT 9917
-#define FM7_BUFFER_SIZE 312
+#define FM7_BUFFER_SIZE 311
 
 static void fm7_parse_telemetry(ForzaTelemetry *telemetry, void *buffer)
 {


### PR DESCRIPTION
Telemetry buffer size should be 311 instead of 312 for Forza Motorsport 7

Fixes #3 