### PR TITLE
Use recv instead of recvfrom

### DIFF
--- a/src/forza.c
+++ b/src/forza.c
@@ -11,6 +11,7 @@
 
 // Games sorted by release
 int (*game_socket_inits[])(void) = {start_fm7_socket, start_fh4_socket, start_fh5_socket};
+int (*game_socket_destructors[])(const int) = {destruct_fm7, destruct_fh4, destruct_fh5};
 int (*game_socket_handlers[])(const int) = {handle_fm7_socket_data, handle_fh4_socket_data, handle_fh5_socket_data};
 
 static ForzaTelemetry *latest_telemetry = NULL;
@@ -45,6 +46,21 @@ int start_all_sockets(void)
 
         pollfds[i] =
             (struct pollfd){.fd = sockfd, .events = POLLIN};
+    }
+
+    return failures;
+}
+
+int stop_all_sockets(void)
+{
+    int failures = 0;
+
+    for (int i = 0; i < GAME_COUNT; i++)
+    {
+        const int sockfd = pollfds[i].fd;
+
+        if (game_socket_destructors[i](sockfd) != 0)
+            failures++;
     }
 
     return failures;

--- a/src/games/fh4.c
+++ b/src/games/fh4.c
@@ -368,27 +368,20 @@ int start_fh4_socket(void)
 
     const int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
     if (sockfd < 0)
-    {
-        perror("An error occurred creating FH4 socket");
         return 0;
-    }
 
     servaddr.sin_family = AF_INET;
     servaddr.sin_port = htons(FH4_PORT);
     servaddr.sin_addr.s_addr = inet_addr(IP_ADDRESS);
 
     if (bind(sockfd, (const struct sockaddr *)&servaddr, sizeof(servaddr)) < 0)
-    {
-        perror("An error occurred binding FH4 socket");
-        return 0;
-    }
+        return -1;
 
     return sockfd;
 }
 
 int handle_fh4_socket_data(const int sockfd)
 {
-
     socklen_t len;
     struct sockaddr cliaddr;
 
@@ -398,10 +391,13 @@ int handle_fh4_socket_data(const int sockfd)
 
     const ssize_t msg_len = recvfrom(sockfd, buffer, FH4_BUFFER_SIZE, MSG_WAITALL, &cliaddr, &len);
 
+    if (msg_len < 0)
+        return 1;
+
     if (msg_len != FH4_BUFFER_SIZE)
-        return 0;
+        return 2;
 
     fh4_parse_telemetry(telemetry, buffer);
 
-    return 1;
+    return 0;
 }

--- a/src/games/fh4.c
+++ b/src/games/fh4.c
@@ -380,6 +380,11 @@ int start_fh4_socket(void)
     return sockfd;
 }
 
+int destruct_fh4(const int sockfd)
+{
+    return close(sockfd);
+}
+
 int handle_fh4_socket_data(const int sockfd)
 {
     socklen_t len;

--- a/src/games/fh4.c
+++ b/src/games/fh4.c
@@ -387,14 +387,11 @@ int destruct_fh4(const int sockfd)
 
 int handle_fh4_socket_data(const int sockfd)
 {
-    socklen_t len;
-    struct sockaddr cliaddr;
-
     void *buffer = alloca(FH4_BUFFER_SIZE);
 
     ForzaTelemetry *telemetry = get_latest_telemetry();
 
-    const ssize_t msg_len = recvfrom(sockfd, buffer, FH4_BUFFER_SIZE, MSG_WAITALL, &cliaddr, &len);
+    const ssize_t msg_len = recv(sockfd, buffer, FH4_BUFFER_SIZE, MSG_WAITALL);
 
     if (msg_len < 0)
         return 1;

--- a/src/games/fh4.h
+++ b/src/games/fh4.h
@@ -2,4 +2,6 @@
 
 int start_fh4_socket(void);
 
+int destruct_fh4(const int sockfd);
+
 int handle_fh4_socket_data(const int sockfd);

--- a/src/games/fh5.c
+++ b/src/games/fh5.c
@@ -387,14 +387,11 @@ int destruct_fh5(const int sockfd)
 
 int handle_fh5_socket_data(const int sockfd)
 {
-    socklen_t len;
-    struct sockaddr cliaddr;
-
     void *buffer = alloca(FH5_BUFFER_SIZE);
 
     ForzaTelemetry *telemetry = get_latest_telemetry();
 
-    const ssize_t msg_len = recvfrom(sockfd, buffer, FH5_BUFFER_SIZE, MSG_WAITALL, &cliaddr, &len);
+    const ssize_t msg_len = recv(sockfd, buffer, FH5_BUFFER_SIZE, MSG_WAITALL);
 
     if (msg_len < 0)
         return 1;

--- a/src/games/fh5.c
+++ b/src/games/fh5.c
@@ -368,20 +368,14 @@ int start_fh5_socket(void)
 
     const int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
     if (sockfd < 0)
-    {
-        perror("An error occurred creating FH5 socket");
         return 0;
-    }
 
     servaddr.sin_family = AF_INET;
     servaddr.sin_port = htons(FH5_PORT);
     servaddr.sin_addr.s_addr = inet_addr(IP_ADDRESS);
 
     if (bind(sockfd, (const struct sockaddr *)&servaddr, sizeof(servaddr)) < 0)
-    {
-        perror("An error occurred binding FH5 socket");
-        return 0;
-    }
+        return -1;
 
     return sockfd;
 }
@@ -397,10 +391,13 @@ int handle_fh5_socket_data(const int sockfd)
 
     const ssize_t msg_len = recvfrom(sockfd, buffer, FH5_BUFFER_SIZE, MSG_WAITALL, &cliaddr, &len);
 
+    if (msg_len < 0)
+        return 1;
+
     if (msg_len != FH5_BUFFER_SIZE)
-        return 0;
+        return 2;
 
     fh5_parse_telemetry(telemetry, buffer);
 
-    return 1;
+    return 0;
 }

--- a/src/games/fh5.c
+++ b/src/games/fh5.c
@@ -380,6 +380,11 @@ int start_fh5_socket(void)
     return sockfd;
 }
 
+int destruct_fh5(const int sockfd)
+{
+    return close(sockfd);
+}
+
 int handle_fh5_socket_data(const int sockfd)
 {
     socklen_t len;

--- a/src/games/fh5.h
+++ b/src/games/fh5.h
@@ -2,4 +2,6 @@
 
 int start_fh5_socket(void);
 
+int destruct_fh5(const int sockfd);
+
 int handle_fh5_socket_data(const int sockfd);

--- a/src/games/fm7.c
+++ b/src/games/fm7.c
@@ -384,14 +384,11 @@ int destruct_fm7(const int sockfd)
 
 int handle_fm7_socket_data(const int sockfd)
 {
-    socklen_t len;
-    struct sockaddr cliaddr;
-
     void *buffer = alloca(FM7_BUFFER_SIZE);
 
     ForzaTelemetry *telemetry = get_latest_telemetry();
 
-    const ssize_t msg_len = recvfrom(sockfd, buffer, FM7_BUFFER_SIZE, MSG_WAITALL, &cliaddr, &len);
+    const ssize_t msg_len = recv(sockfd, buffer, FM7_BUFFER_SIZE, MSG_WAITALL);
 
     if (msg_len < 0)
         return 1;

--- a/src/games/fm7.c
+++ b/src/games/fm7.c
@@ -377,6 +377,11 @@ int start_fm7_socket(void)
     return sockfd;
 }
 
+int destruct_fm7(const int sockfd)
+{
+    return close(sockfd);
+}
+
 int handle_fm7_socket_data(const int sockfd)
 {
     socklen_t len;

--- a/src/games/fm7.c
+++ b/src/games/fm7.c
@@ -365,20 +365,14 @@ int start_fm7_socket(void)
 
     const int sockfd = socket(AF_INET, SOCK_DGRAM, 0);
     if (sockfd < 0)
-    {
-        perror("An error occurred creating FM7 socket");
         return 0;
-    }
 
     servaddr.sin_family = AF_INET;
     servaddr.sin_port = htons(FM7_PORT);
     servaddr.sin_addr.s_addr = inet_addr(IP_ADDRESS);
 
     if (bind(sockfd, (const struct sockaddr *)&servaddr, sizeof(servaddr)) < 0)
-    {
-        perror("An error occurred binding FM7 socket");
         return 0;
-    }
 
     return sockfd;
 }
@@ -394,10 +388,13 @@ int handle_fm7_socket_data(const int sockfd)
 
     const ssize_t msg_len = recvfrom(sockfd, buffer, FM7_BUFFER_SIZE, MSG_WAITALL, &cliaddr, &len);
 
+    if (msg_len < 0)
+        return 1;
+
     if (msg_len != FM7_BUFFER_SIZE)
-        return 0;
+        return 2;
 
     fm7_parse_telemetry(telemetry, buffer);
 
-    return 1;
+    return 0;
 }

--- a/src/games/fm7.h
+++ b/src/games/fm7.h
@@ -2,4 +2,6 @@
 
 int start_fm7_socket(void);
 
+int destruct_fm7(const int sockfd);
+
 int handle_fm7_socket_data(const int sockfd);


### PR DESCRIPTION
`recvfrom` was used to receive data from sockets, requiring extra parameters `struct sockaddr *src_addr, socklen_t *addrlen`, neither of which were used in the library apart from early testing.

Previously, `msg_len` was not initialized which led to errors on some platforms (#2)

Instead of fixing `msg_len` by initializing it to the size of the buffer associated with `src_addr`, this PR changes `recvfrom` to `recv` which no longer includes either `src_addr` or `addrlen` as parameters.

The `recv()` call is normally used only on a connected socket, but the source address was discarded anyway, making it unnecessary.

Fixes #2